### PR TITLE
feature: fetch countdown progress ring

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,6 +963,8 @@ function showRateLimitBanner(seconds) {
       STATE.rateLimited = false;
       banner.classList.remove('visible');
       clearInterval(STATE.rateLimitTimer);
+      const ring = document.getElementById('fetchRingProgress');
+      if (ring) ring.classList.remove('rate-limited');
     }
   }, 1000);
 }
@@ -1151,14 +1153,12 @@ function schedulePriceFetch() {
   }
 
   STATE.countdownTimer = setInterval(() => {
+    if (STATE.rateLimited) return;
     const total = STATE.fetchInterval * 1000;
     const elapsed = Date.now() - (STATE.nextFetchTime - total);
     const pct = Math.min(100, (elapsed / total) * 100);
     const ring = document.getElementById('fetchRingProgress');
-    if (ring) {
-      ring.classList.remove('rate-limited');
-      ring.style.strokeDashoffset = (37.7 * (1 - pct / 100)).toFixed(2);
-    }
+    if (ring) ring.style.strokeDashoffset = (37.7 * (1 - pct / 100)).toFixed(2);
   }, 250);
 
   STATE.priceTimer = setTimeout(() => {


### PR DESCRIPTION
Re-opens #22 targeting main directly.

Replaces the text countdown with an SVG progress ring in the monitor toolbar. The ring fills as the next fetch approaches and turns amber during rate-limit pauses.

Post-review fixes: guard countdown interval tick against STATE.rateLimited so it cannot fight the rate-limited class; remove rate-limited class when the ban lifts rather than waiting for the next schedulePriceFetch call.