### PR TITLE
feature: wishlist total cost + reserve time from base data

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,7 +900,6 @@ const STATE = {
   showReserve: false,      // Reserve-Zeit-Spalte ein-/ausgeblendet
   gameData: null,          // gecachte gamedata.json (Rezepte, Buildings)
   baseTimer: null,
-  baseInterval: 300,       // Base-Daten alle 5 Minuten abrufen
   prices: [],
   running: false,
   priceTimer: null,
@@ -1233,7 +1232,7 @@ async function startWishlistMonitoring() {
   fetchPrices();
   schedulePriceFetch();
   scheduleWishlistFetch();
-  if (STATE.showReserve) { fetchBaseData(); scheduleBaseData(); }
+  if (STATE.showReserve) fetchBaseData();
 }
 
 function stopMonitoring() {
@@ -1412,15 +1411,6 @@ async function fetchBaseData() {
   }
 }
 
-function scheduleBaseData() {
-  clearTimeout(STATE.baseTimer);
-  STATE.baseTimer = setTimeout(() => {
-    if (!STATE.running || !STATE.showReserve) return;
-    fetchBaseData();
-    scheduleBaseData();
-  }, STATE.baseInterval * 1000);
-}
-
 function toggleReserve() {
   STATE.showReserve = !STATE.showReserve;
   document.body.classList.toggle('mode-reserve', STATE.showReserve);
@@ -1431,7 +1421,6 @@ function toggleReserve() {
   }
   if (STATE.showReserve) {
     fetchBaseData();
-    scheduleBaseData();
   } else {
     clearTimeout(STATE.baseTimer);
     STATE.reserveData = {};


### PR DESCRIPTION
closes #10

## Changelog

### Wishlist — Menge & Gesamteinkaufswert
- `wishlistAmounts` in STATE: speichert `am`-Feld (Menge) pro Material aus der Wishlist-API
- Neue Spalten **Menge** und **Gesamtwert** (`Menge × Aktueller Preis`) in der Tabelle — nur im Wishlist-Modus sichtbar (`body.mode-wishlist` CSS-Klasse)
- **Summenzeile** (`<tfoot>`) zeigt Gesamtbudget aller Wishlist-Materialien
- Sortierung nach Gesamtwert möglich (`toggleSort('total')`)

### Reserve-Zeit
- Neuer Toggle **🏭/⏳ Reserven** im Toolbar (nur Wishlist-Modus) — Shortcut `B`
- `fetchBaseData()` ruft `GET /public/company/bases` (20 Pts.) ab und berechnet:
  - **Workforce-Verbrauch** aus `workforce.consumptionMaterials[].rate`
  - **Produktions-Nettofluss** aus aktiven `buildingSlots` + `productionOrders` via `gamedata.json`-Rezepten
  - `gamedata.json` wird einmalig gecacht (`STATE.gameData`) — keine Auth, keine API-Kosten
  - Building Productivity: `min(cond + 0.2, 1.0)` (Worker Satisfaction folgt in #37)
- **Kostenoptimierung:** Base-Daten werden nur einmal geladen wenn der Toggle aktiviert wird — kein automatischer Re-Fetch. Ergebnis bleibt bis Toggle-Deaktivierung erhalten (20 Pts. statt 20 Pts./5min)
- **Zeitformat** `2h 30m` / `1d 4h` / `∞` (netto produziert) statt Dezimaltage
- Urgent-Schwellenwert: < 1 Tag (rot), sonst grün
- Reserve-Spalte nur sichtbar wenn Toggle aktiv (`body.mode-reserve`)
- Sortierung nach Reserve möglich; deaktiviert wenn Toggle aus

### Historischer Ø — Spalte ein-/ausblenden
- `body.mode-hist` CSS-Klasse wird in `setAlarmMode()` und `syncHistControls()` gesetzt
- Spalte „Historischer Ø" nur sichtbar wenn Alarm-Basis auf „Hist. Ø" steht

### Code-Review-Fixes
- `Math.round()` vor `formatNum()` entfernt (doppelte Rundung)
- IIFE für `reserveCell` → `renderReserveCell()` + `formatReserve()` Helper-Funktionen
- `toggleSort('reserve')` no-op wenn Reserve-Toggle inaktiv
- `<tfoot id="priceTableFoot">` statisch im HTML, kein DOM-Anhängen/-Entfernen
- `colspan` in Summenzeile dynamisch berechnet
- Alle Debug-`console.log`s entfernt
- `stopMonitoring()` cleared jetzt auch `STATE.baseTimer`

## Follow-up
- #37 — Worker Satisfaction in Production Speed einbeziehen