### PR TITLE
feature: multi-wishlist, search-add, context menu (#23)

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,6 +489,103 @@
   }
   .sell-toggle:hover, .sell-toggle.sell-active { opacity: 1; }
 
+  tr.wl-group-header td {
+    background: var(--bg-deep);
+    color: var(--text-dim);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    padding: 5px 12px;
+    border-top: 2px solid var(--border);
+  }
+
+  tr.ghost-row { opacity: 0.45; }
+  tr.ghost-row:hover { opacity: 0.75; }
+
+  .wl-add-select {
+    background: var(--bg-panel);
+    color: var(--text);
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 0.82rem;
+    cursor: pointer;
+    max-width: 150px;
+  }
+  .wl-add-select:focus { outline: none; border-color: var(--accent); }
+
+  #contextMenu {
+    position: fixed;
+    z-index: 9000;
+    background: var(--bg-panel);
+    border: 1px solid var(--border-bright);
+    border-radius: 8px;
+    padding: 4px 0;
+    min-width: 200px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+    font-size: 13px;
+  }
+  .ctx-header {
+    padding: 6px 14px 4px;
+    color: var(--text-dim);
+    font-size: 11px;
+    font-family: 'JetBrains Mono', monospace;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 2px;
+  }
+  .ctx-section {
+    padding: 2px 0;
+    border-top: 1px solid var(--border);
+    margin-top: 2px;
+  }
+  .ctx-label {
+    padding: 3px 14px;
+    color: var(--text-dim);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+  }
+  .ctx-item {
+    padding: 6px 14px;
+    cursor: pointer;
+    color: var(--text);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: background 0.1s;
+  }
+  .ctx-item:hover { background: var(--bg-hover); }
+  .ctx-item.danger { color: var(--danger); }
+  .ctx-new-list {
+    padding: 4px 10px;
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+  .ctx-new-input {
+    flex: 1;
+    background: var(--bg-deep);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 3px 7px;
+    font-size: 12px;
+  }
+  .ctx-new-input:focus { outline: none; border-color: var(--accent); }
+  .ctx-new-btn {
+    background: var(--accent);
+    color: #000;
+    border: none;
+    border-radius: 4px;
+    padding: 3px 8px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
   .no-data {
     text-align: center;
     padding: 60px 20px;
@@ -753,6 +850,10 @@
 
 <!-- TOASTS -->
 <div id="toast-container"></div>
+
+<!-- CONTEXT MENU -->
+<div id="contextMenu" style="display:none;"></div>
+
 <div id="spark-tooltip" style="display:none;position:fixed;background:var(--bg-panel);border:1px solid var(--border);border-radius:6px;padding:6px 10px;font-size:0.75rem;pointer-events:none;z-index:9999;white-space:nowrap;"></div>
 
 <!-- MAIN -->
@@ -925,8 +1026,10 @@ const STATE = {
   fetchInterval: 15,
   wishlistInterval: 60,
   deviationThreshold: 10,
-  selectedWishlistId: null,
-  selectedWishlistName: '',
+  selectedWishlistId: null,       // compat (erstes/einziges Element aus selectedWishlistIds)
+  selectedWishlistName: '',       // compat
+  selectedWishlistIds: new Set(), // alle aktuell ausgewählten Wishlist-IDs
+  selectedWishlistNames: {},      // { id: displayName }
   wishlistMatIds: new Set(),
   wishlistAmounts: {},     // { matId: am } — Mengen aus der Wishlist
   wishlistSellFlags: {},   // { 'wlId:matId': true } — true = Sell-Modus
@@ -954,12 +1057,18 @@ const STATE = {
   apiHistoryLoaded: false,
   localTrackingStart: 0,  // timestamp of first local snapshot
   lastFetchTime: null,  // timestamp of last successful price fetch
+  generalWishlistId: null,    // ID der "General"-Wishlist (lazy via API angelegt)
+  ghostSellFlags: {},         // { matId: false } — nur gesetzt wenn Buy-Modus; default ist Sell (true)
+  allWishlists: [],           // [{ id, name }] — alle bekannten Wishlists
+  wishlistAmountsById: {},    // { wlId: { matId: amount } } — Mengen pro Wishlist
 };
 
 // ─── COST TRACKER ───
 const COSTS = {
   '/public/wishlists': 7,
   '/public/wishlist': 3,
+  '/public/wishlist/create': 30,        // Custom-Wishlist anlegen
+  '/public/wishlist/additems': 5,       // TODO: tatsächliche Kosten in API-Docs prüfen
   '/public/exchange/mat-prices': 5,
   '/public/exchange/mat-details':   60,  // alle Materialien, 7 Tage Historie
   '/public/exchange/mat-details/':   5,  // einzelnes Material, 30 Tage Historie
@@ -1014,10 +1123,12 @@ function wouldExceedLimit(endpoint) {
 // ─── API ───
 const API_BASE = 'https://api.g2.galactictycoons.com';
 
-async function apiFetch(path) {
+async function apiFetch(path, opts = {}) {
   if (STATE.rateLimited) throw new Error('RATE_LIMITED');
 
-  const endpointKey = path.startsWith('/public/wishlist/') ? '/public/wishlist' :
+  const endpointKey = path === '/public/wishlist/create' ? '/public/wishlist/create' :
+                      path.endsWith('/additems') ? '/public/wishlist/additems' :
+                      path.startsWith('/public/wishlist/') ? '/public/wishlist' :
                       path.startsWith('/public/wishlists') ? '/public/wishlists' :
                       path.startsWith('/public/exchange/mat-prices') ? '/public/exchange/mat-prices' :
                       path.startsWith('/public/exchange/mat-details/') ? '/public/exchange/mat-details/' :
@@ -1028,12 +1139,19 @@ async function apiFetch(path) {
     throw new Error('RATE_LIMITED');
   }
 
-  const res = await fetch(API_BASE + path, {
+  const fetchOpts = {
+    method: opts.method || 'GET',
     headers: {
       'Authorization': 'Bearer ' + STATE.apiKey,
       'Accept': 'application/json',
-    }
-  });
+    },
+  };
+  if (opts.body !== undefined) {
+    fetchOpts.headers['Content-Type'] = 'application/json';
+    fetchOpts.body = JSON.stringify(opts.body);
+  }
+
+  const res = await fetch(API_BASE + path, fetchOpts);
 
   if (res.status === 429) {
     const retryAfter = parseInt(res.headers.get('Retry-After') || '60', 10);
@@ -1126,7 +1244,7 @@ function saveSellFlags() {
   try { localStorage.setItem('gt_monitor_sell_flags', JSON.stringify(STATE.wishlistSellFlags)); } catch(e) {}
 }
 function sellKey(matId) {
-  return (STATE.selectedWishlistId ?? 'all') + ':' + matId;
+  return String(matId);
 }
 function toggleSellFlag(matId) {
   const key = sellKey(matId);
@@ -1136,6 +1254,229 @@ function toggleSellFlag(matId) {
 }
 function isSell(matId) {
   return !!STATE.wishlistSellFlags[sellKey(matId)];
+}
+
+// ─── GHOST-ROW SELL-TOGGLE (vor dem Hinzufügen zur General-Wishlist) ───
+// Default: Sell (true). ghostSellFlags[matId] = false bedeutet Buy-Modus.
+function isGhostSell(matId) {
+  return STATE.ghostSellFlags[matId] !== false;
+}
+function toggleGhostSell(matId) {
+  STATE.ghostSellFlags[matId] = !isGhostSell(matId);
+  renderTable();
+}
+
+// ─── GENERAL-WISHLIST ───
+async function ensureGeneralWishlist() {
+  if (STATE.generalWishlistId) return;
+  const saved = localStorage.getItem('gt_monitor_general_wl_id');
+  if (saved) { STATE.generalWishlistId = Number(saved); return; }
+
+  // Wishlists abrufen und nach "General" suchen
+  const data = await apiFetch('/public/wishlists');
+  const wls = Array.isArray(data) ? data : (data.wishlists || data.items || data.data || []);
+  const existing = wls.find(wl => (wl.title || wl.name) === 'General');
+
+  if (existing) {
+    STATE.generalWishlistId = existing.id ?? existing.wishlistId;
+  } else {
+    const created = await apiFetch('/public/wishlist/create', { method: 'POST', body: { title: 'General' } });
+    STATE.generalWishlistId = created.id ?? created.wishlistId;
+    toast('General-Wishlist angelegt.', 'info');
+  }
+  localStorage.setItem('gt_monitor_general_wl_id', String(STATE.generalWishlistId));
+}
+
+// Generalisierte Wishlist-Operationen
+async function addToWishlist(matId, wishlistId, asSell) {
+  const mat = STATE.prices.find(p => p.matId === matId);
+  const matName = mat ? mat.matName : 'Material #' + matId;
+  const wl = STATE.allWishlists.find(w => w.id === wishlistId);
+  const wlName = wl ? wl.name : '#' + wishlistId;
+  try {
+    await apiFetch('/public/wishlist/' + wishlistId + '/additems', {
+      method: 'POST',
+      body: [{ id: matId, am: 1 }],
+    });
+    // Optimistic: lokalen State aktualisieren
+    if (!STATE.wishlistAmountsById[wishlistId]) STATE.wishlistAmountsById[wishlistId] = {};
+    STATE.wishlistAmountsById[wishlistId][matId] = 1;
+    // Sell-Flag setzen (Key = matId, konsistent mit sellKey())
+    STATE.wishlistSellFlags[sellKey(matId)] = !!asSell;
+    saveSellFlags();
+    delete STATE.ghostSellFlags[matId];
+    toast(esc(matName) + ' → ' + esc(wlName) + ' (' + (asSell ? '💰' : '🛒') + ')', 'info');
+    if (STATE.selectedWishlistIds.has(wishlistId)) {
+      rebuildMergedAmounts();
+      renderTable();
+    }
+  } catch(e) {
+    if (e.message !== 'RATE_LIMITED') toast('Fehler beim Hinzufügen: ' + esc(e.message), 'warn');
+  }
+}
+
+async function removeFromWishlist(matId, wishlistId) {
+  const mat = STATE.prices.find(p => p.matId === matId);
+  const matName = mat ? mat.matName : 'Material #' + matId;
+  const wl = STATE.allWishlists.find(w => w.id === wishlistId);
+  const wlName = wl ? wl.name : '#' + wishlistId;
+  const currentAm = (STATE.wishlistAmountsById[wishlistId] || {})[matId] || 1;
+  try {
+    await apiFetch('/public/wishlist/' + wishlistId + '/additems', {
+      method: 'POST',
+      body: [{ id: matId, am: -currentAm }],
+    });
+    if (STATE.wishlistAmountsById[wishlistId]) delete STATE.wishlistAmountsById[wishlistId][matId];
+    toast(esc(matName) + ' aus ' + esc(wlName) + ' entfernt', 'info');
+    if (STATE.selectedWishlistIds.has(wishlistId)) {
+      rebuildMergedAmounts();
+      renderTable();
+    }
+  } catch(e) {
+    if (e.message !== 'RATE_LIMITED') toast('Fehler beim Entfernen: ' + esc(e.message), 'warn');
+  }
+}
+
+async function moveToWishlist(matId, fromId, toId) {
+  await addToWishlist(matId, toId, isSell(matId));
+  await removeFromWishlist(matId, fromId);
+}
+
+async function createWishlistAndAdd(matId, title, asSell) {
+  try {
+    const created = await apiFetch('/public/wishlist/create', { method: 'POST', body: { title } });
+    const newId = created.id ?? created.wishlistId;
+    STATE.allWishlists.push({ id: newId, name: title });
+    STATE.selectedWishlistNames[newId] = title;
+    toast('Liste "' + esc(title) + '" angelegt.', 'info');
+    await addToWishlist(matId, newId, asSell);
+  } catch(e) {
+    if (e.message !== 'RATE_LIMITED') toast('Fehler beim Erstellen: ' + esc(e.message), 'warn');
+  }
+}
+
+function rebuildMergedAmounts() {
+  const amounts = {};
+  for (const [wlId, perWl] of Object.entries(STATE.wishlistAmountsById)) {
+    if (!STATE.selectedWishlistIds.has(Number(wlId))) continue;
+    for (const [mid, am] of Object.entries(perWl)) {
+      amounts[mid] = (amounts[mid] || 0) + am;
+    }
+  }
+  STATE.wishlistAmounts = amounts;
+  STATE.wishlistMatIds = new Set(Object.keys(amounts).map(Number));
+}
+
+async function handleGhostAdd(selectEl, matId) {
+  const val = selectEl.value;
+  selectEl.value = '';
+  if (!val) return;
+  const asSell = isGhostSell(matId);
+  if (val === 'new') {
+    const title = window.prompt('Name der neuen Liste:');
+    if (title && title.trim()) await createWishlistAndAdd(matId, title.trim(), asSell);
+  } else {
+    await addToWishlist(matId, Number(val), asSell);
+  }
+}
+
+// Compat-Wrapper
+async function addToGeneralWishlist(matId) {
+  await ensureGeneralWishlist();
+  await addToWishlist(matId, STATE.generalWishlistId, isGhostSell(matId));
+}
+
+// ─── CONTEXT MENU ───
+function hideContextMenu() {
+  const m = document.getElementById('contextMenu');
+  m.style.display = 'none';
+  m.innerHTML = '';
+}
+
+document.addEventListener('click', e => {
+  const menu = document.getElementById('contextMenu');
+  if (!menu.contains(e.target)) hideContextMenu();
+});
+document.addEventListener('keydown', e => { if (e.key === 'Escape') hideContextMenu(); });
+
+function showContextMenu(matId, x, y) {
+  const mat = STATE.prices.find(p => p.matId === matId);
+  if (!mat) return;
+
+  // Wishlists die dieses Mat enthalten (unter den bekannten)
+  const containingIds = STATE.allWishlists
+    .map(w => w.id)
+    .filter(id => (STATE.wishlistAmountsById[id] || {})[matId] != null);
+  const notContainingIds = STATE.allWishlists
+    .map(w => w.id)
+    .filter(id => (STATE.wishlistAmountsById[id] || {})[matId] == null);
+
+  let html = `<div class="ctx-header">${esc(mat.matName)}</div>`;
+
+  // Hinzufügen zu…
+  if (notContainingIds.length > 0 || true /* immer "Neue Liste" zeigen */) {
+    html += `<div class="ctx-section">`;
+    html += `<div class="ctx-label">Hinzufügen zu</div>`;
+    notContainingIds.forEach(id => {
+      const name = (STATE.allWishlists.find(w => w.id === id) || {}).name || '#' + id;
+      html += `<div class="ctx-item" onclick="addToWishlist(${matId},${id},${isSell(matId)});hideContextMenu()">✚ ${esc(name)}</div>`;
+    });
+    html += `<div class="ctx-new-list">
+      <input class="ctx-new-input" id="ctxNewName" placeholder="Neue Liste…" onkeydown="if(event.key==='Enter')ctxCreateAndAdd(${matId})">
+      <button class="ctx-new-btn" onclick="ctxCreateAndAdd(${matId})">+</button>
+    </div>`;
+    html += `</div>`;
+  }
+
+  // Verschieben (von A nach B) — nur wenn in mind. einer Liste und mind. eine andere existiert
+  const movePairs = [];
+  containingIds.forEach(fromId => {
+    notContainingIds.forEach(toId => {
+      movePairs.push({ fromId, toId });
+    });
+  });
+  if (movePairs.length > 0) {
+    html += `<div class="ctx-section"><div class="ctx-label">Verschieben</div>`;
+    movePairs.forEach(({ fromId, toId }) => {
+      const from = (STATE.allWishlists.find(w => w.id === fromId) || {}).name || '#' + fromId;
+      const to = (STATE.allWishlists.find(w => w.id === toId) || {}).name || '#' + toId;
+      html += `<div class="ctx-item" onclick="moveToWishlist(${matId},${fromId},${toId});hideContextMenu()">➡ ${esc(from)} → ${esc(to)}</div>`;
+    });
+    html += `</div>`;
+  }
+
+  // Entfernen von…
+  if (containingIds.length > 0) {
+    html += `<div class="ctx-section"><div class="ctx-label">Entfernen von</div>`;
+    containingIds.forEach(id => {
+      const name = (STATE.allWishlists.find(w => w.id === id) || {}).name || '#' + id;
+      html += `<div class="ctx-item danger" onclick="removeFromWishlist(${matId},${id});hideContextMenu()">✕ ${esc(name)}</div>`;
+    });
+    html += `</div>`;
+  }
+
+  const menu = document.getElementById('contextMenu');
+  menu.innerHTML = html;
+  menu.style.display = 'block';
+
+  // Positionierung: nicht über den Rand
+  const vw = window.innerWidth, vh = window.innerHeight;
+  const mw = 220, mh = 300; // geschätzte Abmessungen
+  menu.style.left = (x + mw > vw ? vw - mw - 8 : x) + 'px';
+  menu.style.top  = (y + mh > vh ? y - Math.min(mh, y - 8) : y) + 'px';
+
+  // Fokus auf Neues-Listen-Input setzen falls vorhanden und keine anderen Optionen
+  if (notContainingIds.length === 0) {
+    setTimeout(() => document.getElementById('ctxNewName')?.focus(), 50);
+  }
+}
+
+function ctxCreateAndAdd(matId) {
+  const input = document.getElementById('ctxNewName');
+  const title = input ? input.value.trim() : '';
+  if (!title) return;
+  hideContextMenu();
+  createWishlistAndAdd(matId, title, isSell(matId));
 }
 
 function saveSettings() {
@@ -1179,6 +1520,8 @@ async function loadWishlists() {
   document.getElementById('wishlistList').innerHTML = '';
   document.getElementById('btnStartWishlist').disabled = true;
   STATE.selectedWishlistId = null;
+  STATE.selectedWishlistIds.clear();
+  STATE.selectedWishlistNames = {};
 
   try {
     const data = await apiFetch('/public/wishlists');
@@ -1202,22 +1545,19 @@ async function loadWishlists() {
       document.getElementById('wishlistList').innerHTML = '<div class="no-data">Keine Wishlists gefunden.</div>';
       return;
     }
-    // Auto-select if only one wishlist exists
-    if (wishlists.length === 1) {
-      const wl = wishlists[0];
-      STATE.selectedWishlistId = wl.id ?? wl.wishlistId;
-      STATE.selectedWishlistName = wl.title || wl.name || wl.wishlistName || ('Planet-Wishlist #' + STATE.selectedWishlistId);
-      startWishlistMonitoring();
-      return;
-    }
+    STATE.allWishlists = wishlists.map(wl => {
+      const id = wl.id ?? wl.wishlistId;
+      const name = wl.title || wl.name || wl.wishlistName || ('Planet-Wishlist #' + id);
+      return { id, name };
+    });
+
     const container = document.getElementById('wishlistList');
     wishlists.forEach(wl => {
       const wlId = wl.id ?? wl.wishlistId;
-      // title field from API (can be null for planet wishlists), fallback to name
       const wlTitle = wl.title || wl.name || wl.wishlistName || null;
       const displayName = wlTitle || ('Planet-Wishlist #' + wlId);
-      // Count materials if available
       const matCount = (wl.mats || wl.materials || wl.items || []).length;
+      STATE.selectedWishlistNames[wlId] = displayName;
 
       const div = document.createElement('div');
       div.className = 'wishlist-item';
@@ -1226,14 +1566,24 @@ async function loadWishlists() {
         <span class="wishlist-item-count">${matCount ? matCount + ' Mat.' : ''} #${wlId}</span>
       `;
       div.addEventListener('click', () => {
-        document.querySelectorAll('.wishlist-item').forEach(i => i.classList.remove('selected'));
-        div.classList.add('selected');
-        STATE.selectedWishlistId = wlId;
-        STATE.selectedWishlistName = displayName;
-        document.getElementById('btnStartWishlist').disabled = false;
+        if (STATE.selectedWishlistIds.has(wlId)) {
+          STATE.selectedWishlistIds.delete(wlId);
+          div.classList.remove('selected');
+        } else {
+          STATE.selectedWishlistIds.add(wlId);
+          div.classList.add('selected');
+        }
+        document.getElementById('btnStartWishlist').disabled = STATE.selectedWishlistIds.size === 0;
       });
       container.appendChild(div);
     });
+
+    // Auto-select und starten wenn nur eine Wishlist vorhanden
+    if (wishlists.length === 1) {
+      container.querySelector('.wishlist-item').click();
+      startWishlistMonitoring();
+      return;
+    }
   } catch(e) {
     document.getElementById('wishlistLoading').style.display = 'none';
     document.getElementById('wishlistList').innerHTML = '<div class="no-data">Fehler: ' + esc(e.message) + '</div>';
@@ -1273,7 +1623,10 @@ async function startWishlistMonitoring() {
   STATE.sortDir = 'asc';
   syncSortHeaders();
   showView('monitor');
-  document.getElementById('monitorTitle').textContent = '⭐ Wishlist: ' + STATE.selectedWishlistName;
+  const names = [...STATE.selectedWishlistIds]
+    .map(id => STATE.selectedWishlistNames[id] || '#' + id)
+    .join(', ');
+  document.getElementById('monitorTitle').textContent = '⭐ ' + names;
   document.getElementById('statusDot').classList.add('active');
   document.getElementById('statusText').textContent = 'Aktiv – Wishlist';
   document.getElementById('noData').style.display = '';
@@ -1347,24 +1700,25 @@ async function fetchPrices() {
 }
 
 async function fetchWishlistDetails() {
-  if (!STATE.running || !STATE.selectedWishlistId) return;
+  if (!STATE.running || STATE.selectedWishlistIds.size === 0) return;
   try {
-    const data = await apiFetch('/public/wishlist/' + STATE.selectedWishlistId);
-    console.log('[GT Monitor] /public/wishlist/' + STATE.selectedWishlistId + ' response:', JSON.stringify(data, null, 2));
-
-    // Handle: the wishlist object might be the data directly or wrapped
-    let wlObj = data;
-
-    // Extract materials array - try all known field names
-    // Local API uses "mats" with {id, am}, Public API might differ
-    const rawMats = wlObj.mats || wlObj.materials || wlObj.items || [];
-    // Extract material IDs and amounts - handle both {id, am} (Local API style) and {matId, ...} formats
+    const ids = [...STATE.selectedWishlistIds];
+    const results = await Promise.all(ids.map(id => apiFetch('/public/wishlist/' + id)));
     const amounts = {};
-    rawMats.forEach(m => {
-      const mid = m.matId ?? m.materialId ?? m.id;
-      if (mid != null) amounts[mid] = m.am ?? m.amount ?? m.quantity ?? 1;
+    results.forEach((data, i) => {
+      const wlId = ids[i];
+      const rawMats = data.mats || data.materials || data.items || [];
+      const perWl = {};
+      rawMats.forEach(m => {
+        const mid = m.matId ?? m.materialId ?? m.id;
+        if (mid != null) {
+          const am = m.am ?? m.amount ?? m.quantity ?? 1;
+          perWl[mid] = am;
+          amounts[mid] = (amounts[mid] || 0) + am;
+        }
+      });
+      STATE.wishlistAmountsById[wlId] = perWl;
     });
-
     STATE.wishlistAmounts = amounts;
     STATE.wishlistMatIds = new Set(Object.keys(amounts).map(Number));
     updateApiHistCost();
@@ -1844,12 +2198,17 @@ function renderTable() {
         if (a.deviation === null && b.deviation === null) return 0;
         if (a.deviation === null) return 1;
         if (b.deviation === null) return -1;
-        return dir * (a.deviation - b.deviation);
+        // Sell-Items: hohe Abweichung = gut → effektiv negieren für einheitliche "beste zuerst"-Sortierung
+        { const aEff = isSell(a.matId) ? -a.deviation : a.deviation;
+          const bEff = isSell(b.matId) ? -b.deviation : b.deviation;
+          return dir * (aEff - bEff); }
       default:
         if (a.deviation === null && b.deviation === null) return 0;
         if (a.deviation === null) return 1;
         if (b.deviation === null) return -1;
-        return a.deviation - b.deviation;
+        { const aEff = isSell(a.matId) ? -a.deviation : a.deviation;
+          const bEff = isSell(b.matId) ? -b.deviation : b.deviation;
+          return aEff - bEff; }
     }
   });
 
@@ -1868,7 +2227,7 @@ function renderTable() {
 
   const tfoot = document.getElementById('priceTableFoot');
 
-  tbody.innerHTML = items.map(p => {
+  const renderRow = p => {
     const sell = isSell(p.matId);
     const histCell = p.histAvg !== null ? formatNum(p.histAvg) : '—';
     const amCell = `<td class="col-wishlist">${p.am ?? '—'}</td>`;
@@ -1876,7 +2235,7 @@ function renderTable() {
     const reserveCell = renderReserveCell(p.reserve);
     const toggleBtn = `<button class="sell-toggle${sell ? ' sell-active' : ''}" onclick="toggleSellFlag(${p.matId})" title="${sell ? 'Verkaufen – zu Kaufen wechseln' : 'Kaufen – zu Verkaufen wechseln'}">${sell ? '💰' : '🛒'}</button>`;
     if (p.deviation === null) {
-      return `<tr data-matid="${p.matId}">
+      return `<tr data-matid="${p.matId}" oncontextmenu="event.preventDefault();showContextMenu(${p.matId},event.clientX,event.clientY)">
         <td class="td-name">${toggleBtn}${esc(p.matName)}</td>
         <td>${p.currentPrice === -1 ? '—' : formatNum(p.currentPrice)}</td>
         ${amCell}${totalCell}${reserveCell}
@@ -1886,16 +2245,13 @@ function renderTable() {
         <td class="spark-cell" colspan="2">${renderSparkline(p.sparkHistory, sell, true)}</td>
       </tr>`;
     }
-
     const devStr = (p.deviation >= 0 ? '+' : '') + p.deviation.toFixed(2) + '%';
     const isAlert = sell ? p.deviation >= STATE.deviationThreshold : p.deviation <= threshold;
-    // Buy: grün wenn niedrig (ok), rot wenn hoch (warn) — Sell: invertiert
     const devClass = isAlert ? 'alert'
       : sell ? (p.deviation >= 0 ? 'ok' : 'warn')
              : (p.deviation >= 0 ? 'warn' : 'ok');
     const sparkSvg = renderSparkline(p.sparkHistory, sell, !isAlert);
-
-    return `<tr class="${isAlert ? 'alarm-row' : ''}" data-matid="${p.matId}">
+    return `<tr class="${isAlert ? 'alarm-row' : ''}" data-matid="${p.matId}" oncontextmenu="event.preventDefault();showContextMenu(${p.matId},event.clientX,event.clientY)">
       <td class="td-name">${toggleBtn}${esc(p.matName)}</td>
       <td>${formatNum(p.currentPrice)}</td>
       ${amCell}${totalCell}${reserveCell}
@@ -1906,7 +2262,56 @@ function renderTable() {
         ? `<td class="spark-cell">${sparkSvg}</td><td><span class="alarm-badge">🔔 ALARM</span></td>`
         : `<td class="spark-cell" colspan="2">${sparkSvg}</td>`}
     </tr>`;
-  }).join('');
+  };
+
+  // Gruppen-Trennung: bei mehreren Wishlists Trennzeilen mit Namen einfügen
+  const colCount = 8 + (STATE.showReserve ? 1 : 0);
+  if (STATE.mode === 'wishlist' && STATE.selectedWishlistIds.size > 1) {
+    const groupHtml = [];
+    for (const wlId of [...STATE.selectedWishlistIds].sort((a, b) => a - b)) {
+      const wlItems = items.filter(p => (STATE.wishlistAmountsById[wlId] || {})[p.matId] != null);
+      if (!wlItems.length) continue;
+      const name = STATE.selectedWishlistNames[wlId] || '#' + wlId;
+      groupHtml.push(`<tr class="wl-group-header"><td colspan="${colCount}">⭐ ${esc(name)}</td></tr>`);
+      wlItems.forEach(p => groupHtml.push(renderRow(p)));
+    }
+    tbody.innerHTML = groupHtml.join('');
+  } else {
+    tbody.innerHTML = items.map(renderRow).join('');
+  }
+
+  // Ghost-Rows: passende Suchergebnisse die NICHT in der aktuellen Wishlist sind
+  if (STATE.mode === 'wishlist' && query) {
+    const ghostItems = STATE.prices
+      .filter(p => p.matName.toLowerCase().includes(query))
+      .filter(p => !STATE.wishlistMatIds.has(p.matId));
+    if (ghostItems.length > 0) {
+      const reserveColEmpty = STATE.showReserve ? '<td class="col-reserve">—</td>' : '';
+      const wlOptions = STATE.allWishlists
+        .map(w => `<option value="${w.id}">${esc(w.name)}</option>`)
+        .join('');
+      tbody.innerHTML += ghostItems.map(p => {
+        const sell = isGhostSell(p.matId);
+        const toggleBtn = `<button class="sell-toggle${sell ? ' sell-active' : ''}" onclick="toggleGhostSell(${p.matId})" title="${sell ? 'Auf Kaufen wechseln' : 'Auf Verkaufen wechseln'}">${sell ? '💰' : '🛒'}</button>`;
+        const addSelect = `<select class="wl-add-select" onchange="handleGhostAdd(this,${p.matId})" title="Zur Wishlist hinzufügen">
+          <option value="">+ Hinzufügen…</option>
+          ${wlOptions}
+          <option value="new">── Neue Liste ──</option>
+        </select>`;
+        return `<tr class="ghost-row" data-matid="${p.matId}">
+          <td class="td-name">${toggleBtn}${esc(p.matName)}</td>
+          <td>${p.currentPrice > 0 ? formatNum(p.currentPrice) : '—'}</td>
+          <td class="col-wishlist">—</td>
+          <td class="col-wishlist">—</td>
+          ${reserveColEmpty}
+          <td>${p.avgPrice > 0 ? formatNum(p.avgPrice) : '—'}</td>
+          <td class="col-hist">—</td>
+          <td><span class="td-deviation neutral">—</span></td>
+          <td class="spark-cell" colspan="2">${addSelect}</td>
+        </tr>`;
+      }).join('');
+    }
+  }
 
   const sparkCache = new Map(items.map(p => [p.matId, p.sparkHistory]));
   document.querySelectorAll('#priceTableBody .sparkline').forEach(svg => {


### PR DESCRIPTION
## Summary

Erweitert die Wishlist-Überwachung um Multi-Select, direktes Hinzufügen aus der Suche und ein Rechtsklick-Kontextmenü zur Listenverwaltung.

## Changes

### Features
- **Multi-Wishlist-Auswahl**: Mehrere Wishlists gleichzeitig überwachen (Toggle-Select), Mengen werden summiert
- **Ghost-Rows in Suche**: Im Wishlist-Modus zeigt die Suche nicht enthaltene Mats gedimmt mit Dropdown zum Hinzufügen
- **Rechtsklick-Kontextmenü**: Auf jeder Zeile → Hinzufügen zu / Entfernen von / Verschieben zwischen Wishlists
- **Neue Liste anlegen**: Direkt aus Dropdown oder Kontextmenü heraus (POST `/public/wishlist/create`)
- **Sell-Default**: Beim Hinzufügen aus der Suche standardmäßig als Verkaufen markiert (togglebar)
- **Gruppen-Trennung**: Bei mehreren Wishlists werden Tabellengruppen mit Listennamen als Header angezeigt

### Bugfixes
- **Sell-Sort**: Sell-Items mit positiver Abweichung sortieren jetzt korrekt oben (invertierte Effektivwert-Logik)
- **Toggle-Persistenz**: `sellKey()` vereinfacht auf `matId` — Flag bleibt über Wishlist-Refreshes erhalten
- **POST-Support in apiFetch**: Unterstützt jetzt `method` und `body` Parameter

## Dependencies
- Requires #17 (sparkline charts, base branch)
- Depends on #14 (search field) ✓
- Depends on #15 (sortable columns) ✓

closes #23