### PR TITLE
fix: per-wishlist amounts in grouped multi-wishlist view

### DIFF
--- a/index.html
+++ b/index.html
@@ -2274,6 +2274,7 @@ function renderTable() {
       const name = STATE.selectedWishlistNames[wlId] || '#' + wlId;
       groupHtml.push(`<tr class="wl-group-header"><td colspan="${colCount}">⭐ ${esc(name)}</td></tr>`);
       wlItems.forEach(p => {
+        if (isSell(p.matId)) { groupHtml.push(renderRow(p)); return; }
         const wlAm = (STATE.wishlistAmountsById[wlId] || {})[p.matId] ?? null;
         const wlTotal = (wlAm != null && p.currentPrice > 0) ? wlAm * p.currentPrice : null;
         groupHtml.push(renderRow({ ...p, am: wlAm, total: wlTotal }));


### PR DESCRIPTION
## Problem

When a material appeared in more than one selected wishlist with different amounts, the grouped table showed the **summed total** for every row instead of each list's individual amount. This made it impossible to use a separate consumables list alongside the regular wishlist.

## Root cause

`p.am` and `p.total` were computed once from `STATE.wishlistAmounts[matId]` (the merged total across all selected lists). The grouped rendering loop called `renderRow(p)` as-is, so every group showed the same summed value.

## Fix

In the grouping loop, override `am` and `total` with the per-wishlist values from `STATE.wishlistAmountsById[wlId][matId]` before passing to `renderRow`.

## Dependencies

Depends on / fixes #44

Closes #44